### PR TITLE
Allow usage of Ansible module group defaults

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,28 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: ">=2.9.10"
+action_groups:
+  netapp_elementsw:
+    - na_elementsw_access_group
+    - na_elementsw_access_group_volumes
+    - na_elementsw_account
+    - na_elementsw_admin_users
+    - na_elementsw_backup
+    - na_elementsw_check_connections
+    - na_elementsw_cluster_config
+    - na_elementsw_cluster_pair
+    - na_elementsw_cluster
+    - na_elementsw_cluster_snmp
+    - na_elementsw_drive
+    - na_elementsw_info
+    - na_elementsw_initiators
+    - na_elementsw_ldap
+    - na_elementsw_network_interfaces
+    - na_elementsw_node
+    - na_elementsw_qos_policy
+    - na_elementsw_snapshot
+    - na_elementsw_snapshot_restore
+    - na_elementsw_snapshot_schedule
+    - na_elementsw_vlan
+    - na_elementsw_volume_clone
+    - na_elementsw_volume_pair
+    - na_elementsw_volume


### PR DESCRIPTION
##### SUMMARY
Allow usage of Ansible module group defaults

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html

##### ADDITIONAL INFORMATION
Allows usage of module defaults like:
```
- hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - netapp.elementsw
  module_defaults:
    group/netapp.ontap.netapp_elementsw:
       # common options goes here
```